### PR TITLE
#issue with nsupdate on  Ubuntu 14.04.1 LTS

### DIFF
--- a/dnsapi/dns_nsupdate.sh
+++ b/dnsapi/dns_nsupdate.sh
@@ -8,12 +8,14 @@ dns_nsupdate_add() {
   txtvalue=$2
   _checkKeyFile || return 1
   [ -n "${NSUPDATE_SERVER}" ] || NSUPDATE_SERVER="localhost"
+  [ -n "${NSUPDATE_SERVER_PORT}" ] || NSUPDATE_SERVER_PORT=53
   # save the dns server and key to the account conf file.
-  _saveaccountconf NSUPDATE_SERVER "${NSUPDATE_SERVER}"
+  _saveaccountconf NSUPDATE_SERVER "${NSUPDATE_SERVER} "
+  _saveaccountconf NSUPDATE_SERVER_PORT "${NSUPDATE_SERVER_PORT} "  
   _saveaccountconf NSUPDATE_KEY "${NSUPDATE_KEY}"
   _info "adding ${fulldomain}. 60 in txt \"${txtvalue}\""
   nsupdate -k "${NSUPDATE_KEY}" <<EOF
-server ${NSUPDATE_SERVER}
+server ${NSUPDATE_SERVER} -p ${NSUPDATE_SERVER_PORT} 
 update add ${fulldomain}. 60 in txt "${txtvalue}"
 send
 EOF
@@ -30,9 +32,10 @@ dns_nsupdate_rm() {
   fulldomain=$1
   _checkKeyFile || return 1
   [ -n "${NSUPDATE_SERVER}" ] || NSUPDATE_SERVER="localhost"
+  [ -n "${NSUPDATE_SERVER_PORT}" ] || NSUPDATE_SERVER_PORT=53
   _info "removing ${fulldomain}. txt"
   nsupdate -k "${NSUPDATE_KEY}" <<EOF
-server ${NSUPDATE_SERVER}
+server ${NSUPDATE_SERVER} -p ${NSUPDATE_SERVER_PORT} 
 update delete ${fulldomain}. txt
 send
 EOF


### PR DESCRIPTION
on  Ubuntu 14.04.1 LTS if nsupdate runs without port number given it treated argument following server name as port number.
and throws error: 
```
port 'update' is not numeric
syntax error
```

<!--

Do NOT send pull request to `master` branch.

Please send to `dev` branch instead.

Any PR to `master` branch will NOT be merged.

-->